### PR TITLE
Add GitHub workflow to publish to gh-pages

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,33 @@
+name: Deploy to GitHub Pages
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  deploy:
+    name: Deploy to GitHub Pages
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Use Node.js 14.x
+      uses: actions/setup-node@v2
+      with:
+        node-version: 14.x
+
+    - run: npm install --global yarn
+
+    - run: yarn
+      env:
+        CI: true
+
+    - run: yarn build
+
+    - name: Deploy
+      uses: s0/git-publish-subdir-action@develop
+      env:
+        REPO: self
+        BRANCH: gh-pages
+        FOLDER: build
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "dsp-calculator",
   "version": "0.1.0",
   "private": true,
+  "homepage": ".",
   "dependencies": {
     "@testing-library/jest-dom": "^5.11.4",
     "@testing-library/react": "^11.1.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -74,6 +74,7 @@ function getRecipeContent(
     return (
       <ul>
         <li>
+          {/* eslint-disable-next-line */}
           <a href="#" onClick={onClick}>
             {ingredient.item}: {(quantity * ingredient.quantity) / recipe.yields}
           </a>


### PR DESCRIPTION
With this workflow, every push to master branch will automatically be built and published to gh-pages branch.

Fixes #1

You may need to enable gh-pages from your repository settings:

![image](https://user-images.githubusercontent.com/1330321/105808062-0e2cd980-5fe2-11eb-9a26-7772713efd2b.png)

CRA build script treats warnings as errors in CI environment, so I temporally suppressed one eslint warning.